### PR TITLE
Large Files

### DIFF
--- a/pcap_binding.cc
+++ b/pcap_binding.cc
@@ -100,10 +100,8 @@ Dispatch(const Arguments& args)
     Local<Function> callback = Local<Function>::Cast(args[1]);
 
     int packet_count, total_packets = 0;
-    do {
-        packet_count = pcap_dispatch(pcap_handle, 1, PacketReady, (u_char *)&callback);
-        total_packets += packet_count;
-    } while (packet_count > 0);
+    packet_count = pcap_dispatch(pcap_handle, 1, PacketReady, (u_char *)&callback);
+    total_packets += packet_count;
 
     return scope.Close(Integer::NewFromUnsigned(total_packets));
 }

--- a/pcap_binding.cc
+++ b/pcap_binding.cc
@@ -99,9 +99,8 @@ Dispatch(const Arguments& args)
 
     Local<Function> callback = Local<Function>::Cast(args[1]);
 
-    int packet_count, total_packets = 0;
-    packet_count = pcap_dispatch(pcap_handle, 1, PacketReady, (u_char *)&callback);
-    total_packets += packet_count;
+    int total_packets = 0;
+    total_packets = pcap_dispatch(pcap_handle, 1, PacketReady, (u_char *)&callback);
 
     return scope.Close(Integer::NewFromUnsigned(total_packets));
 }


### PR DESCRIPTION
We tried reading large (1-100GB) pcap files with node-pcap and ran into some problems.

It seemed as though the file reads were eating up the entire event loop, and nothing else was being allowed through (database calls, http calls, anything else we tried to do).  This basically worked fine on smaller files that we tried (10-50mb), because it would read the entire file contents, and then all the other database and http calls would get processed after, and you wouldn't notice anything wrong.

With the larger files, obviously we will run out of memory when we have 100gb of packets queuing up tasks that cant get executed until all the packets are read.

After some debugging, we found that the IOWatcher callback was actually only getting called once ever (at the beginning), and that essentially all of the packet_ready() callbacks were getting called from just 1 binding.dispatch() call.  This does not seem to be how things are supposed to work.

Essentially, we found that removing the do..while() loop in pcap_binding.cc resolved the issue for us and lets node get back into its event loop.  I'm not sure if there are side effects to this that we haven't seen yet, as I'm not 100% certain as to the need for the do..while() loop to begin with.

I tested this on 10GB files fine with no issues and no missed packets (comparing against tcpdump).  I also tested this with live traffic and it seemed to perform fine there as well.

Can you let me know your thoughts on this change and possibly any side effects it may incur?  Thanks a bunch.