### PR TITLE
Several updates for the node_pcap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Archived Repo
 =============
 
-**This is an archived fork and is no longer supported or updated by Facebook. Please do not file issues or pull-requests against this repo. The primary on-going source of the project may now be found at https://github.com/tornadoweb/tornado**
+**This is an archived fork and is no longer supported or updated by Facebook. Please do not file issues or pull-requests against this repo. The primary on-going source of the project may now be found at https://github.com/mranney/node_pcap**
 
 node_pcap
 =========

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+Archived Repo
+=============
+
+**This is an archived fork and is no longer supported or updated by Facebook. Please do not file issues or pull-requests against this repo. The primary on-going source of the project may now be found at https://github.com/tornadoweb/tornado**
+
 node_pcap
 =========
 

--- a/pcap.js
+++ b/pcap.js
@@ -1318,6 +1318,8 @@ TCP_tracker.prototype.track_states.ESTAB = function (packet, session) {
     var ip  = packet.link.ip,
         tcp = ip.tcp,
         src = ip.saddr + ":" + tcp.sport;
+    
+    tcp.timestamp = packet.pcap_header.time_ms;
 
 // TODO - actually implement SACK decoding and tracking
 // if (tcp.options.sack) {

--- a/pcap.js
+++ b/pcap.js
@@ -1345,6 +1345,8 @@ TCP_tracker.prototype.track_states.ESTAB = function (packet, session) {
                 } else if (session.websocket_detect) {
                     session.websocket_parser_send.execute(tcp.data);
                     // TODO - check for WS parser errors
+                } else {
+                  this.emit('tcp request', session, tcp);
                 }
             }
             session.send_packets[tcp.seqno + tcp.data_bytes] = packet.pcap_header.time_ms;
@@ -1383,6 +1385,8 @@ TCP_tracker.prototype.track_states.ESTAB = function (packet, session) {
                 } else if (session.websocket_detect) {
                     session.websocket_parser_recv.execute(tcp.data);
                     // TODO - check for WS parser errors
+                } else {
+                  this.emit('tcp response', session, tcp);
                 }
             }
             session.recv_packets[tcp.seqno + tcp.data_bytes] = packet.pcap_header.time_ms;

--- a/pcap.js
+++ b/pcap.js
@@ -1115,7 +1115,10 @@ TCP_tracker.prototype.session_stats = function (session) {
     stats.recv_payload = session.recv_bytes_payload;
     stats.recv_total = stats.recv_overhead + stats.recv_payload;
 
-    if (session.http.request) {
+    // theoretically, if we have incomplete HTTP request it will be recognized
+    // as 'http' and 'http' key will be created.
+    // However, complete request will not be parsed.
+    if (session.http && session.http.request) {
         stats.http_request = session.http.request;
     }
 

--- a/pcap.js
+++ b/pcap.js
@@ -19,6 +19,9 @@ if (process.versions && process.versions.node && process.versions.node.split('.'
 function Pcap() {
     this.opened = false;
     this.fd = null;
+    this.bytesRead = 0;
+    this.pcapHeaderLength = 24;
+    this.pcapPacketHeaderLength = 16;
 
     events.EventEmitter.call(this);
 }
@@ -43,6 +46,7 @@ Pcap.prototype.open = function (live, device, filter, buffer_size) {
         this.device_name = device || binding.default_device();
         this.link_type = binding.open_live(this.device_name, filter || "", this.buffer_size);
     } else {
+        this.bytesRead = this.pcapHeaderLength;
         this.device_name = device;
         this.link_type = binding.open_offline(this.device_name, filter || "", this.buffer_size);
     }
@@ -55,6 +59,7 @@ Pcap.prototype.open = function (live, device, filter, buffer_size) {
 
     // called for each packet read by pcap
     function packet_ready(header) {
+        me.bytesRead += header.caplen + me.pcapPacketHeaderLength;
         header.link_type = me.link_type;
         header.time_ms = (header.tv_sec * 1000) + (header.tv_usec / 1000);
         me.buf.pcap_header = header;


### PR DESCRIPTION
1) Handling of 'eof' in offline dumps
2) emission of tcp packets (not only http)
3) Small fix for session_stats
4) Added byte counter (useful for status reporting on offline analyze of huge dumps)
5) Added multiple session support (rather simple, it is not very suitable for millions of dumps). It just allows to open several dumps in the same application.
6) Change RST flag handling. In some dumps it arrived in arbitrary state machine state. 
7) Added timestamp to each tcp packet.