### PR TITLE
pcap: session_stats: Check that http is defined

### DIFF
--- a/pcap.js
+++ b/pcap.js
@@ -1414,7 +1414,7 @@ TCP_tracker.prototype.session_stats = function (session) {
     stats.recv_payload = session.recv_bytes_payload;
     stats.recv_total = stats.recv_overhead + stats.recv_payload;
 
-    if (session.http.request) {
+    if (session.http && session.http.request) {
         stats.http_request = session.http.request;
     }
 


### PR DESCRIPTION
* Check that the http object is defined prior to checking for the request
  object to prevent a TypeError.

Example error:

    $ sudo node node_modules/pcap/examples/tcp_metrics em1
    Listening on em1
    pcap.js: decode.ethernet() - Don't know how to decode ethertype 34932
    pcap.js: decode.ethernet() - Don't know how to decode ethertype 34932
    pcap.js: decode.ethernet() - Don't know how to decode ethertype 34932
    pcap.js: decode.ethernet() - Don't know how to decode ethertype 34932
    pcap.js: decode.ethernet() - Don't know how to decode ethertype 34932
    pcap.js: decode.ethernet() - Don't know how to decode ethertype 34932
    pcap.js: decode.ethernet() - Don't know how to decode ethertype 34932
    pcap.js: decode.ethernet() - Don't know how to decode ethertype 34932
    Start of TCP session between 10.33.3.224:50431 and 74.125.20.211:443
    Start of TCP session between 10.33.3.224:34493 and 74.125.239.132:443
    End of TCP session between 10.33.3.224:34493 and 74.125.239.132:443

    /home/user/netstash/node_modules/pcap/pcap.js:1417
        if (session.http.request) {
                        ^
    TypeError: Cannot read property 'request' of undefined
        at TCP_tracker.session_stats (/home/user/netstash/node_modules/pcap/pcap.js:1417:21)
        at TCP_tracker.<anonymous> (/home/user/netstash/node_modules/pcap/examples/tcp_metrics:37:70)
        at TCP_tracker.EventEmitter.emit (events.js:95:17)
        at TCP_tracker.track_states.LAST_ACK (/home/user/netstash/node_modules/pcap/pcap.js:1692:14)
        at TCP_tracker.track_next (/home/user/netstash/node_modules/pcap/pcap.js:1727:42)
        at TCP_tracker.track_packet (/home/user/netstash/node_modules/pcap/pcap.js:1797:22)
        at Pcap.<anonymous> (/home/user/netstash/node_modules/pcap/examples/tcp_metrics:44:17)
        at Pcap.EventEmitter.emit (events.js:95:17)
        at packet_ready (/home/user/netstash/node_modules/pcap/pcap.js:42:12)
        at SocketWatcher.pcap_read_callback [as callback] (/home/user/netstash/node_modules/pcap/pcap.js:62:43)