### PR TITLE
Add protocol name to decoded IPv4/IPv6 packet

### DIFF
--- a/decode/ipv4.js
+++ b/decode/ipv4.js
@@ -80,23 +80,29 @@ IPv4.prototype.decode = function (raw_packet, offset) {
 
     switch (this.protocol) {
     case 1:
-        this.payload = new ICMP();
-        this.payload.decode(raw_packet, offset);
+        this.payload = new ICMP().decode(raw_packet, offset);
+        this.protocol_name = "ICMP";
         break;
     case 2:
         this.payload = new IGMP().decode(raw_packet, offset);
+        this.protocol_name = "IGMP";
         break;
     case 4:
         this.payload = new IPv4().decode(raw_packet, offset);
+        this.protocol_name = "IPv4";
+        break;
         break;
     case 6:
         this.payload = new TCP().decode(raw_packet, offset, this.total_length - this.header_bytes);
+        this.protocol_name = "TCP";
         break;
     case 17:
         this.payload = new UDP().decode(raw_packet, offset);
+        this.protocol_name = "UDP";
         break;
     case 41:
         this.payload = new IPv6().decode(raw_packet, offset);
+        this.protocol_name = "IPv6";
         break;
     default:
         this.protocol_name = "Unknown";

--- a/decode/ipv6.js
+++ b/decode/ipv6.js
@@ -13,21 +13,27 @@ IPv6Header.prototype.decode = function (raw_packet, next_header, ip, offset) {
     switch (next_header) {
     case 1:
         ip.payload = new ICMP().decode(raw_packet, offset);
+        ip.protocol_name = "ICMP";
         break;
     case 2:
         ip.payload = new IGMP().decode(raw_packet, offset);
+        ip.protocol_name = "IGMP";
         break;
     case 4:
         ip.payload = new IPv4().decode(raw_packet, offset); // IPv4 encapsulation, RFC2003
+        ip.protocol_name = "IPv4";
         break;
     case 6:
         ip.payload = new TCP().decode(raw_packet, offset, ip);
+        ip.protocol_name = "TCP";
         break;
     case 17:
         ip.payload = new UDP().decode(raw_packet, offset);
+        ip.protocol_name = "UDP";
         break;
     case 41:
         ip.payload = new IPv6().decode(raw_packet, offset); // IPv6 encapsulation, RFC2473
+        ip.protocol_name = "IPv6";
         break;
     /* Please follow numbers and RFC in http://www.iana.org/assignments/ipv6-parameters/ipv6-parameters.xhtml#extension-header
      * Not all next protocols follow this rule (and we can have unsuported upper protocols here too).


### PR DESCRIPTION
Since the commit 7a53a84a994725e246f44589f38d1e48dfd8b310, node_pcap doesn't have value of protocol_name field in decoded IPv4/IPv6 packet object.
If there are some reasons why the `protocol_name` filed was removed, simply reject this pull-request and 
remove protocol_name field in decode/ipv4.js:43 and :102, please.