### PR TITLE
Add parentheses to constructor calls

### DIFF
--- a/decode/llc_packet.js
+++ b/decode/llc_packet.js
@@ -33,3 +33,4 @@ LogicalLinkControl.prototype.decode = function (raw_packet, offset) {
 
     return this;
 };
+module.exports = LogicalLinkControl;

--- a/decode/pcap_packet.js
+++ b/decode/pcap_packet.js
@@ -42,7 +42,7 @@ PcapPacket.prototype.decode = function (packet_with_header) {
         this.payload = new RawPacket().decode(buf, 0);
         break;
     case "LINKTYPE_IEEE802_11_RADIO":
-        this.payload = new RadioPacket.decode(buf, 0);
+        this.payload = new RadioPacket().decode(buf, 0);
         break;
     case "LINKTYPE_LINUX_SLL":
         this.payload = new SLLPacket().decode(buf, 0);

--- a/decode/radio_frame.js
+++ b/decode/radio_frame.js
@@ -39,7 +39,7 @@ RadioFrame.prototype.decode = function (raw_packet, offset) {
     } else if (ret.type == 2 && ret.subType == 6) {
         // skip this is CF-Poll (No data)
     } else if (ret.type == 2) { // data
-        ret.llc = new LogicalLinkControl.decode(raw_packet, offset);
+        ret.llc = new LogicalLinkControl().decode(raw_packet, offset);
     }
 
     return ret;


### PR DESCRIPTION
This fixes an issue I was having whilst parsing a capture containing `link_type: 'LINKTYPE_IEEE802_11_RADIO'` packets.