### PR TITLE
skip TCP experimental options from RFC 6994

### DIFF
--- a/decode/tcp.js
+++ b/decode/tcp.js
@@ -124,6 +124,11 @@ TCPOptions.prototype.decode = function (raw_packet, offset, len) {
             this.echo = raw_packet.readUInt32BE(offset);
             offset += 4;
             break;
+        case 254:
+        case 255:
+            console.log("Don't know how to process experimental TCP option " + raw_packet[offset]);
+            offset += raw_packet.readUInt8(offset + 1);
+            break;
         default:
             throw new Error("Don't know how to process TCP option " + raw_packet[offset]);
         }

--- a/decode/tcp.js
+++ b/decode/tcp.js
@@ -126,7 +126,7 @@ TCPOptions.prototype.decode = function (raw_packet, offset, len) {
             break;
         case 254:
         case 255:
-            console.log("Don't know how to process experimental TCP option " + raw_packet[offset]);
+            //console.log("Don't know how to process experimental TCP option " + raw_packet[offset]);
             offset += raw_packet.readUInt8(offset + 1);
             break;
         default:


### PR DESCRIPTION
I just encountered a dump which used experimental options from RFC 6994 -- https://tools.ietf.org/html/rfc6994#section-3
which was running into the default throw section. This just skips them.

Single-packet dump located at http://knecht.hancke.name/tcpopt.pcapng