### PR TITLE
mac address formatting

### DIFF
--- a/decode/ieee802.11/radio_frame.js
+++ b/decode/ieee802.11/radio_frame.js
@@ -51,9 +51,9 @@ RadioFrame.prototype.decode = function (raw_packet, offset) {
     this.subType = (this.frameControl >> 4) & 0x000f;
     this.flags = new RadioFrameFlags().decode((this.frameControl >> 8) & 0xff);
     this.duration = raw_packet.readUInt16BE(offset, true); offset += 2;
-    this.bssid = new EthernetAddr(raw_packet, offset); offset += 6;
-    this.shost = new EthernetAddr(raw_packet, offset); offset += 6;
-    this.dhost = new EthernetAddr(raw_packet, offset); offset += 6;
+    this.bssid = new EthernetAddr(raw_packet, offset).toString(); offset += 6;
+    this.shost = new EthernetAddr(raw_packet, offset).toString(); offset += 6;
+    this.dhost = new EthernetAddr(raw_packet, offset).toString(); offset += 6;
     this.fragSeq = raw_packet.readUInt16BE(offset, true); offset += 2;
 
     if (this.type === 0) {


### PR DESCRIPTION
The bssid, shost and dhost were returning as ints. Added .toString() that already exists as a function in EthernetAddr to return each one in correct mac format.