### PR TITLE
Add grunt-cli to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-mocha-istanbul": "^2.3.1",
     "grunt-mocha-test": "^0.12.7",


### PR DESCRIPTION
Such that grunt does not need to be installed globally for npm test to run.