### PR TITLE
Attach all output into a controllable logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This structure is easy to explore with `sys.inspect`.
 TCP can be analyzed by feeding the packets into a `TCPTracker` and then listening for `session` and `end` events.
 
 ```javascript
-var pcap = require('./pcap'),
+var pcap = require('pcap'),
     tcp_tracker = new pcap.TCPTracker(),
     pcap_session = pcap.createSession('en0', "ip proto \\tcp");
 
@@ -128,6 +128,16 @@ You must only send IPv4 TCP packets to the TCP tracker.  Explore the `session` o
 see the wonderful things it can do for you.  Hopefully the names of the properties are self-explanatory:
 
 See [http_trace](https://github.com/mranney/http_trace) for an example of how to use these events to decode HTTP (Works only on node 4).
+
+### Logging
+
+By default, all logging goes to `console`. All exposed methods support an optional `setLogger` function that takes in
+a logging component (such as [bunyan](https://www.npmjs.com/package/bunyan) or [winston](https://www.npmjs.com/package/winston))
+to direct logging into your application's preferred style.
+
+If you'd like to disable logging altogether, simple pass `false` into the `setLogger` function.
+
+Note: If you use the `pcap.decode` mechanism, your logger must be passed as an optional 3rd argument.
 
 ## Some Common Problems
 

--- a/decode/ethernet_packet.js
+++ b/decode/ethernet_packet.js
@@ -4,8 +4,9 @@ var IPv6 = require("./ipv6");
 var Arp = require("./arp");
 var Vlan = require("./vlan");
 
-function EthernetPacket(emitter) {
+function EthernetPacket(emitter, logger) {
     this.emitter = emitter;
+    this.logger = logger;
     this.dhost = null;
     this.shost = null;
     this.ethertype = null;
@@ -49,7 +50,7 @@ EthernetPacket.prototype.decode = function (raw_packet, offset) {
             this.payload = "need to implement LLDP";
             break;
         default:
-            console.log("node_pcap: EthernetFrame() - Don't know how to decode ethertype " + this.ethertype);
+            this.logger.log("node_pcap: EthernetFrame() - Don't know how to decode ethertype " + this.ethertype);
         }
     }
 

--- a/decode/ieee802.11/radio_packet.js
+++ b/decode/ieee802.11/radio_packet.js
@@ -39,8 +39,9 @@ PresentFieldFlags.prototype.decode = function decode (flags) {
     return this;
 };
 
-function RadioPacket(emitter) {
+function RadioPacket(emitter, logger) {
     this.emitter = emitter;
+    this.logger = logger;
     this.headerRevision = undefined;
     this.headerPad = undefined;
     this.headerLength = undefined;
@@ -95,7 +96,7 @@ RadioPacket.prototype.decode = function (raw_packet, offset) {
     if(p.txAttenuation) { offset++; }
     if(p.dbTxAttenuation) { offset += 2; }
     if(p.dbmTxPower) { offset++; }
-    if(p.antenna) { 
+    if(p.antenna) {
         this.antenna = raw_packet[offset++];
     }
     if(p.dbAntennaSignal) { offset++; }

--- a/decode/index.js
+++ b/decode/index.js
@@ -7,8 +7,11 @@ exports.ArpPacket = require("./arp");
 exports.PcapPacket = require("./pcap_packet");
 var PcapPacket = exports.PcapPacket;
 
-function decode(packet, emitter) {
-    return new PcapPacket(emitter).decode(packet);
+function decode(packet, emitter, logger) {
+    if (typeof logger === "undefined") {
+        logger = console;
+    }
+    return new PcapPacket(emitter, logger).decode(packet);
 }
 
 exports.decode = decode;

--- a/decode/ipv4.js
+++ b/decode/ipv4.js
@@ -31,8 +31,9 @@ IPFlags.prototype.toString = function () {
     return ret;
 };
 
-function IPv4(emitter) {
-    this.emitter = emitter; 
+function IPv4(emitter, logger) {
+    this.emitter = emitter;
+    this.logger = logger;
     this.version = undefined;
     this.headerLength = undefined;
     this.diffserv = undefined;
@@ -116,7 +117,7 @@ IPv4.prototype.toString = function () {
     } else {
         ret += this.payload.constructor.name;
     }
-    
+
 
     return ret + " " + this.payload;
 };

--- a/decode/null_packet.js
+++ b/decode/null_packet.js
@@ -1,8 +1,9 @@
 var IPv4 = require("./ipv4");
 var IPv6 = require("./ipv6");
 
-function NullPacket(emitter) {
+function NullPacket(emitter, logger) {
     this.emitter = emitter;
+    this.logger = logger;
     this.pftype = undefined;
     this.payload = undefined;
     this._error = undefined;

--- a/decode/sll_packet.js
+++ b/decode/sll_packet.js
@@ -6,8 +6,9 @@ var IPv4 = require("./ipv4");
 var IPv6 = require("./ipv6");
 var Arp = require("./arp");
 
-function SLLPacket (emitter) {
+function SLLPacket (emitter, logger) {
     this.emitter = emitter;
+    this.logger = logger;
     this.packet_type = null;
     this.address_type = null;
     this.address_len = null;
@@ -47,7 +48,7 @@ SLLPacket.prototype.decode = function (raw_packet, offset) {
             this.payload = "need to implement LLDP";
             break;
         default:
-            console.log("node_pcap: SLLPacket() - Don't know how to decode ethertype " + this.ethertype);
+            this.logger.log("node_pcap: SLLPacket() - Don't know how to decode ethertype " + this.ethertype);
         }
     }
 

--- a/decode/tcp.js
+++ b/decode/tcp.js
@@ -1,6 +1,6 @@
 
-function TCPFlags(emitter) {
-    this.emitter = emitter;
+function TCPFlags(logger) {
+    this.logger = logger;
     this.nonce = undefined;
     this.cwr = undefined;
     this.ece = undefined;
@@ -57,7 +57,8 @@ TCPFlags.prototype.toString = function () {
     return ret;
 };
 
-function TCPOptions() {
+function TCPOptions(logger) {
+    this.logger = logger;
     this.mss = null;
     this.window_scale = null;
     this.sack_ok = null;
@@ -128,7 +129,7 @@ TCPOptions.prototype.decode = function (raw_packet, offset, len) {
                 offset += 8;
                 break;
             default:
-                console.log("Invalid TCP SACK option length " + raw_packet[offset + 1]);
+                this.logger.log("Invalid TCP SACK option length " + raw_packet[offset + 1]);
                 offset = end_offset;
             }
             break;
@@ -178,6 +179,7 @@ TCPOptions.prototype.toString = function () {
 
 function TCP(emitter) {
     this.emitter        = emitter;
+    this.logger         = console;
     this.sport          = undefined;
     this.dport          = undefined;
     this.seqno          = undefined;
@@ -216,7 +218,7 @@ TCP.prototype.decode = function (raw_packet, offset, len) {
     // of the header.
     this.headerLength    = (raw_packet[offset] & 0xf0) >> 2;
 
-    this.flags = new TCPFlags().decode(raw_packet[offset], raw_packet[offset+1]);
+    this.flags = new TCPFlags(this.logger).decode(raw_packet[offset], raw_packet[offset+1]);
     offset += 2;
     this.windowSize    = raw_packet.readUInt16BE(offset, true); // 14, 15
     offset += 2;

--- a/pcap.js
+++ b/pcap.js
@@ -5,6 +5,7 @@ var SocketWatcher = require("socketwatcher").SocketWatcher;
 var decode        = require("./decode").decode;
 var tcp_tracker   = require("./tcp_tracker");
 var DNSCache      = require("./dns_cache");
+var setLogger     = require("./set_logger");
 var timers        = require("timers");
 
 exports.decode = decode;
@@ -13,6 +14,7 @@ exports.TCPSession = tcp_tracker.TCPSession;
 exports.DNSCache = DNSCache;
 
 function PcapSession(is_live, device_name, filter, buffer_size, outfile, is_monitor) {
+    this.logger = console;
     this.is_live = is_live;
     this.device_name = device_name;
     this.filter = filter || "";
@@ -93,6 +95,8 @@ function PacketWithHeader(buf, header, link_type) {
     this.header = header;
     this.link_type = link_type;
 }
+
+PcapSession.prototype.setLogger = setLogger;
 
 PcapSession.prototype.on_packet_ready = function () {
     var full_packet = new PacketWithHeader(this.buf, this.header, this.link_type);

--- a/set_logger.js
+++ b/set_logger.js
@@ -1,0 +1,18 @@
+function setLogger(logger) {
+    if (typeof logger === "undefined") {
+        this.logger = console;
+    } else if (logger !== false) {
+        this.logger = logger;
+    } else {
+        this.logger = {
+            log: function() { },
+            info: function() { },
+            warn: function() { },
+            error: function() { },
+            trace: function() { }
+        };
+    }
+
+}
+
+module.exports = setLogger;


### PR DESCRIPTION
This change keeps outputting, by default, to console. But it also
introduces a setLogger prototype for every exposed component to
optionally wrap the output into a different logger (e.g. bunyan)
or turn off logging altogether.