### PR TITLE
Only close SocketWatcher when capturing live

### DIFF
--- a/pcap.js
+++ b/pcap.js
@@ -102,7 +102,9 @@ PcapSession.prototype.on_packet_ready = function () {
 PcapSession.prototype.close = function () {
     this.opened = false;
     this.session.close();
-    this.readWatcher.stop();
+    if (this.is_live) {
+        this.readWatcher.stop();
+    }
     // TODO - remove listeners so program will exit I guess?
 };
 


### PR DESCRIPTION
Currently when capturing offline, attempting to close the session results in an error.