### PR TITLE
Using Node_pcap library to sniff the interface live and create pcap file

### DIFF
--- a/examples/pcap_dump_test.js
+++ b/examples/pcap_dump_test.js
@@ -1,0 +1,12 @@
+
+
+
+var pcap = require("../pcap"),
+
+pcap_dump = new pcap.PcapDumpSession('en0', "ip proto \\tcp",10*1024*1024,"tmp61.pcap",false,5);
+
+pcap_dump.on('pcap_write_complete',function(message){
+        console.log("done.....",message);
+});
+
+pcap_dump.start();

--- a/pcap.js
+++ b/pcap.js
@@ -6,11 +6,13 @@ var decode        = require("./decode").decode;
 var tcp_tracker   = require("./tcp_tracker");
 var DNSCache      = require("./dns_cache");
 var timers        = require("timers");
+var pcap_dump     = require("./pcap_dump");
 
 exports.decode = decode;
 exports.TCPTracker = tcp_tracker.TCPTracker;
 exports.TCPSession = tcp_tracker.TCPSession;
 exports.DNSCache = DNSCache;
+exports.PcapDumpSession = pcap_dump.PcapDumpSession;
 
 function PcapSession(is_live, device_name, filter, buffer_size, outfile, is_monitor) {
     this.is_live = is_live;

--- a/pcap_dump.js
+++ b/pcap_dump.js
@@ -1,0 +1,69 @@
+var util = require("util");
+var events = require("events");
+var binding = require("./build/Release/pcap_binding");
+
+
+function PcapDumpSession(device_name, filter, buffer_size, outfile, is_monitor, number_of_packets_to_be_read) {
+    
+    this.device_name = device_name;
+    this.filter = filter || "";
+    this.buffer_size = buffer_size;
+    this.outfile = outfile || "tmp.pcap";
+    this.is_monitor = Boolean(is_monitor);
+    this.opened = null;
+    this.packets_read = 0;
+    this.number_of_packets_to_be_read = number_of_packets_to_be_read || 1
+    this.session = new binding.PcapSession();
+
+    if (typeof this.buffer_size === "number" && !isNaN(this.buffer_size)) {
+        this.buffer_size = Math.round(this.buffer_size);
+    } else {
+        this.buffer_size = 10 * 1024 * 1024; // Default buffer size is 10MB
+    }
+
+    this.device_name = this.device_name || binding.default_device();
+    events.EventEmitter.call(this);
+}
+
+util.inherits(PcapDumpSession, events.EventEmitter);
+
+exports.lib_version = binding.lib_version();
+
+exports.findalldevs = function() {
+    return binding.findalldevs();
+};
+
+PcapDumpSession.prototype.start = function() {
+    
+    this.opened = true;
+    this.session.create_pcapDump(this.device_name, this.filter, this.buffer_size, this.outfile, PcapDumpSession.prototype.on_pcap_write_complete.bind(this), this.is_monitor, this.number_of_packets_to_be_read);
+};
+
+PcapDumpSession.prototype.close = function() {
+    this.opened = false;
+    this.session.close();
+};
+
+PcapDumpSession.prototype.stats = function() {
+    return this.session.stats();
+};
+
+
+PcapDumpSession.prototype.on_pcap_write_complete = function() {
+    this.packets_read = this.packets_read + 1;
+    if (this.packets_read >= this.number_of_packets_to_be_read) {
+        this.emit("pcap_write_complete",{
+            "packets_read":this.packets_read ,
+            "fileName":this.outfile
+        });
+    }
+
+};
+
+
+exports.PcapDumpSession = PcapDumpSession;
+
+
+exports.createPcapDumpSession = function(device, filter, buffer_size, path, monitor, number_of_packets) {
+    return new PcapDumpSession(device, filter, buffer_size, path, monitor, number_of_packets);
+};

--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -28,6 +28,7 @@ void PcapSession::Init(Handle<Object> exports) {
   Nan::SetPrototypeMethod(tpl, "close", Close);
   Nan::SetPrototypeMethod(tpl, "stats", Stats);
   Nan::SetPrototypeMethod(tpl, "inject", Inject);
+  Nan::SetPrototypeMethod(tpl, "create_pcapDump", CreatePcapDump);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("PcapSession").ToLocalChecked(), tpl->GetFunction());
@@ -126,6 +127,7 @@ void PcapSession::Dispatch(const Nan::FunctionCallbackInfo<Value>& info)
 
 void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
 {
+    //this.device_name, this.filter, this.buffer_size, this.outfile, packet_ready, this.is_monitor)
     Nan::HandleScope scope;
     char errbuf[PCAP_ERRBUF_SIZE];
 
@@ -379,4 +381,122 @@ void PcapSession::Inject(const Nan::FunctionCallbackInfo<Value>& info)
         return;
     }
     return;
+}
+
+void PcapSession::CreatePcapDump(const Nan::FunctionCallbackInfo<Value>& info)
+{
+    //this.device_name, this.filter, this.buffer_size, this.outfile, packet_ready, this.is_monitor)
+    Nan::HandleScope scope;
+    char errbuf[PCAP_ERRBUF_SIZE];
+    
+    if (info.Length() == 7) {
+        if (!info[0]->IsString()) {
+            Nan::ThrowTypeError("pcap Open: info[0] must be a String");
+            return;
+        }
+        if (!info[1]->IsString()) {
+            Nan::ThrowTypeError("pcap Open: info[1] must be a String");
+            return;
+        }
+        if (!info[2]->IsInt32()) {
+            Nan::ThrowTypeError("pcap Open: info[2] must be a Number");
+            return;
+        }
+        if (!info[3]->IsString()) {
+            Nan::ThrowTypeError("pcap Open: info[3] must be a String");
+            return;
+        }
+        if (!info[4]->IsFunction()) {
+            Nan::ThrowTypeError("pcap Open: info[4] must be a Function");
+            return;
+        }
+        if (!info[5]->IsBoolean()) {
+            Nan::ThrowTypeError("pcap Open: info[5] must be a Boolean");
+            return;
+        }
+        if (!info[6]->IsInt32()) {
+            Nan::ThrowTypeError("pcap Open: info[6] must be a Number");
+            return;
+        }
+    } else {
+        Nan::ThrowTypeError("pcap CreatePcapDump: expecting 7 arguments");
+        return;
+    }
+    Nan::Utf8String device(info[0]->ToString());
+    Nan::Utf8String filter(info[1]->ToString());
+    int buffer_size = info[2]->Int32Value();
+    Nan::Utf8String pcap_output_filename(info[3]->ToString());
+    int noOfPackets = info[6]->Int32Value();
+    
+    PcapSession* session = Nan::ObjectWrap::Unwrap<PcapSession>(info.This());
+    
+    session->packet_ready_cb.Reset(info[4].As<Function>());
+    session->pcap_dump_handle = NULL;
+    
+   
+        if (pcap_lookupnet((char *) *device, &session->net, &session->mask, errbuf) == -1) {
+            session->net = 0;
+            session->mask = 0;
+            fprintf(stderr, "warning: %s - this may not actually work\n", errbuf);
+        }
+        
+        session->pcap_handle = pcap_create((char *) *device, errbuf);
+        if (session->pcap_handle == NULL) {
+            Nan::ThrowError(errbuf);
+            return;
+        }
+        
+        // 64KB is the max IPv4 packet size
+        if (pcap_set_snaplen(session->pcap_handle, 65535) != 0) {
+            Nan::ThrowError("error setting snaplen");
+            return;
+        }
+        
+        // always use promiscuous mode
+        if (pcap_set_promisc(session->pcap_handle, 1) != 0) {
+            Nan::ThrowError("error setting promiscuous mode");
+            return;
+        }
+        
+        // Try to set buffer size.  Sometimes the OS has a lower limit that it will silently enforce.
+        if (pcap_set_buffer_size(session->pcap_handle, buffer_size) != 0) {
+            Nan::ThrowError("error setting buffer size");
+            return;
+        }
+        
+        // set "timeout" on read, even though we are also setting nonblock below.  On Linux this is required.
+        if (pcap_set_timeout(session->pcap_handle, 1000) != 0) {
+            Nan::ThrowError("error setting read timeout");
+            return;
+        }
+        
+
+        
+        if (pcap_activate(session->pcap_handle) != 0) {
+            Nan::ThrowError(pcap_geterr(session->pcap_handle));
+            return;
+        }
+        
+        if (strlen((char *) *pcap_output_filename) > 0) {
+            session->pcap_dump_handle = pcap_dump_open(session->pcap_handle, (char *) *pcap_output_filename);
+            if (session->pcap_dump_handle == NULL) {
+                Nan::ThrowError("error opening dump");
+                return;
+            }
+        }
+        
+    
+    if (filter.length() != 0) {
+        if (pcap_compile(session->pcap_handle, &session->fp, (char *) *filter, 1, session->net) == -1) {
+            Nan::ThrowError(pcap_geterr(session->pcap_handle));
+            return;
+        }
+        
+        if (pcap_setfilter(session->pcap_handle, &session->fp) == -1) {
+            Nan::ThrowError(pcap_geterr(session->pcap_handle));
+            return;
+        }
+        pcap_freecode(&session->fp);
+    }
+    
 }

--- a/pcap_session.cc
+++ b/pcap_session.cc
@@ -63,6 +63,7 @@ void PcapSession::New(const Nan::FunctionCallbackInfo<Value>& info) {
 void PcapSession::PacketReady(u_char *s, const struct pcap_pkthdr* pkthdr, const u_char* packet) {
     Nan::HandleScope scope;
 
+
     PcapSession* session = (PcapSession *)s;
 
     if (session->pcap_dump_handle != NULL) {
@@ -127,7 +128,6 @@ void PcapSession::Dispatch(const Nan::FunctionCallbackInfo<Value>& info)
 
 void PcapSession::Open(bool live, const Nan::FunctionCallbackInfo<Value>& info)
 {
-    //this.device_name, this.filter, this.buffer_size, this.outfile, packet_ready, this.is_monitor)
     Nan::HandleScope scope;
     char errbuf[PCAP_ERRBUF_SIZE];
 
@@ -383,12 +383,14 @@ void PcapSession::Inject(const Nan::FunctionCallbackInfo<Value>& info)
     return;
 }
 
+
+
 void PcapSession::CreatePcapDump(const Nan::FunctionCallbackInfo<Value>& info)
 {
     //this.device_name, this.filter, this.buffer_size, this.outfile, packet_ready, this.is_monitor)
     Nan::HandleScope scope;
     char errbuf[PCAP_ERRBUF_SIZE];
-    
+
     if (info.Length() == 7) {
         if (!info[0]->IsString()) {
             Nan::ThrowTypeError("pcap Open: info[0] must be a String");
@@ -426,77 +428,80 @@ void PcapSession::CreatePcapDump(const Nan::FunctionCallbackInfo<Value>& info)
     Nan::Utf8String filter(info[1]->ToString());
     int buffer_size = info[2]->Int32Value();
     Nan::Utf8String pcap_output_filename(info[3]->ToString());
-    int noOfPackets = info[6]->Int32Value();
-    
+    int num_packets = info[6]->Int32Value();
+
     PcapSession* session = Nan::ObjectWrap::Unwrap<PcapSession>(info.This());
-    
+
     session->packet_ready_cb.Reset(info[4].As<Function>());
     session->pcap_dump_handle = NULL;
-    
-   
-        if (pcap_lookupnet((char *) *device, &session->net, &session->mask, errbuf) == -1) {
-            session->net = 0;
-            session->mask = 0;
-            fprintf(stderr, "warning: %s - this may not actually work\n", errbuf);
-        }
-        
-        session->pcap_handle = pcap_create((char *) *device, errbuf);
-        if (session->pcap_handle == NULL) {
-            Nan::ThrowError(errbuf);
-            return;
-        }
-        
-        // 64KB is the max IPv4 packet size
-        if (pcap_set_snaplen(session->pcap_handle, 65535) != 0) {
-            Nan::ThrowError("error setting snaplen");
-            return;
-        }
-        
-        // always use promiscuous mode
-        if (pcap_set_promisc(session->pcap_handle, 1) != 0) {
-            Nan::ThrowError("error setting promiscuous mode");
-            return;
-        }
-        
-        // Try to set buffer size.  Sometimes the OS has a lower limit that it will silently enforce.
-        if (pcap_set_buffer_size(session->pcap_handle, buffer_size) != 0) {
-            Nan::ThrowError("error setting buffer size");
-            return;
-        }
-        
-        // set "timeout" on read, even though we are also setting nonblock below.  On Linux this is required.
-        if (pcap_set_timeout(session->pcap_handle, 1000) != 0) {
-            Nan::ThrowError("error setting read timeout");
-            return;
-        }
-        
 
-        
-        if (pcap_activate(session->pcap_handle) != 0) {
-            Nan::ThrowError(pcap_geterr(session->pcap_handle));
+    if (pcap_lookupnet((char *) *device, &session->net, &session->mask, errbuf) == -1) {
+        session->net = 0;
+        session->mask = 0;
+        fprintf(stderr, "warning: %s - this may not actually work\n", errbuf);
+    }
+
+    
+    session->pcap_handle = pcap_create((char *) *device, errbuf);
+    if (session->pcap_handle == NULL) {
+        Nan::ThrowError(errbuf);
+        return;
+    }
+     
+    // 64KB is the max IPv4 packet size
+    if (pcap_set_snaplen(session->pcap_handle, 65535) != 0) {
+        Nan::ThrowError("error setting snaplen");
+        return;
+    }
+
+    // always use promiscuous mode
+    if (pcap_set_promisc(session->pcap_handle, 1) != 0) {
+        Nan::ThrowError("error setting promiscuous mode");
+        return;
+    }
+    
+    // Try to set buffer size.  Sometimes the OS has a lower limit that it will silently enforce.
+    if (pcap_set_buffer_size(session->pcap_handle, buffer_size) != 0) {
+        Nan::ThrowError("error setting buffer size");
+        return;
+    }
+      
+    
+    // set "timeout" on read, even though we are also setting nonblock below.  On Linux this is required.
+    if (pcap_set_timeout(session->pcap_handle, 1000) != 0) {
+        Nan::ThrowError("error setting read timeout");
+        return;
+    }
+    
+    if (pcap_activate(session->pcap_handle) != 0) {
+        Nan::ThrowError(pcap_geterr(session->pcap_handle));
+        return;
+    }
+    
+    if (strlen((char *) *pcap_output_filename) > 0) {
+        session->pcap_dump_handle = pcap_dump_open(session->pcap_handle, (char *) *pcap_output_filename);
+        if (session->pcap_dump_handle == NULL) {
+            Nan::ThrowError("error opening dump");
             return;
         }
-        
-        if (strlen((char *) *pcap_output_filename) > 0) {
-            session->pcap_dump_handle = pcap_dump_open(session->pcap_handle, (char *) *pcap_output_filename);
-            if (session->pcap_dump_handle == NULL) {
-                Nan::ThrowError("error opening dump");
-                return;
-            }
-        }
-        
+    }
+    
     
     if (filter.length() != 0) {
         if (pcap_compile(session->pcap_handle, &session->fp, (char *) *filter, 1, session->net) == -1) {
             Nan::ThrowError(pcap_geterr(session->pcap_handle));
             return;
         }
-        
+           
         if (pcap_setfilter(session->pcap_handle, &session->fp) == -1) {
             Nan::ThrowError(pcap_geterr(session->pcap_handle));
             return;
         }
+
+        pcap_loop(session->pcap_handle, num_packets, PacketReady, (u_char *)session);
         pcap_freecode(&session->fp);
     }
+    
+    info.GetReturnValue().Set(info.This());
     
 }

--- a/pcap_session.h
+++ b/pcap_session.h
@@ -21,6 +21,8 @@ private:
     static void Close(const Nan::FunctionCallbackInfo<v8::Value>& info);
     static void Stats(const Nan::FunctionCallbackInfo<v8::Value>& info);
     static void Inject(const Nan::FunctionCallbackInfo<v8::Value>& info);
+    static void CreatePcapDump(const Nan::FunctionCallbackInfo<v8::Value>& info);
+
     static void PacketReady(u_char *callback_p, const struct pcap_pkthdr* pkthdr, const u_char* packet);
 
     Nan::Persistent<v8::Function> packet_ready_cb;

--- a/pcap_session.h
+++ b/pcap_session.h
@@ -22,8 +22,8 @@ private:
     static void Stats(const Nan::FunctionCallbackInfo<v8::Value>& info);
     static void Inject(const Nan::FunctionCallbackInfo<v8::Value>& info);
     static void CreatePcapDump(const Nan::FunctionCallbackInfo<v8::Value>& info);
-
     static void PacketReady(u_char *callback_p, const struct pcap_pkthdr* pkthdr, const u_char* packet);
+   
 
     Nan::Persistent<v8::Function> packet_ready_cb;
     static Nan::Persistent<v8::Function> constructor;


### PR DESCRIPTION
Using Node_pcap library to sniff the interface live and create pcap file.
currently there is no way in the existing library to create a pcap file. I have created a new method on the add on. A new parameter (total no of packets to be captured ) has been added. Even though code looks more or less the same; i felt it was better to keep to to different method and different js file for code maintainability. there is an example added.

Please let me know this is pull request is good enough for getting merged.
ps: I am still writing the unit test cases, would make a pull request in a day or two for the test cases